### PR TITLE
Remove example and spec alleging that --collection can be specified multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 ============
 
 * Your contribution here.
+* [#9](https://github.com/dblock/mongoid-shell/pull/9) - Remove example and spec alleging that `--collection` can be specified multiple times - [@joeyAghion](https://github.com/joeyAghion).
 
 0.4.2 (2/9/2015)
 ================
 
-* [#8](https://github.com/dblock/mongoid-shell/pull/7) - Support repeatable parameters; add `excludeCollection` and `excludeCollectionsWithPrefix` to `mongodump` - [@joeyAghion](https://github.com/joeyAghion).
+* [#8](https://github.com/dblock/mongoid-shell/pull/8) - Support repeatable parameters; add `excludeCollection` and `excludeCollectionsWithPrefix` to `mongodump` - [@joeyAghion](https://github.com/joeyAghion).
 
 0.4.1 (10/25/2015)
 ==================

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ system mongodump.to_s # mongodump --db another_database --out /tmp/db_backup
 To specify parameters multiple times, set them to arrays.
 
 ``` ruby
-mongodump = Mongoid::Shell::Commands::Mongodump.new(collection: %w(users products))
-system mongodump.to_s # mongodump --collection users --collection products
+mongodump = Mongoid::Shell::Commands::Mongodump.new(excludeCollection: %w(users products))
+system mongodump.to_s # mongodump --excludeCollection users --excludeCollection products
 ```
 
 

--- a/spec/mongoid/commands/mongodump_spec.rb
+++ b/spec/mongoid/commands/mongodump_spec.rb
@@ -11,11 +11,6 @@ describe Mongoid::Shell::Commands::Mongodump do
         collection: 'test'
       ).to_s).to eq 'mongodump --db mongoid_shell_tests --collection test'
     end
-    it 'includes multiple collections' do
-      expect(Mongoid::Shell::Commands::Mongodump.new(
-        collection: %w(test1 test2)
-      ).to_s).to eq 'mongodump --db mongoid_shell_tests --collection test1 --collection test2'
-    end
     it 'includes excludeCollection' do
       expect(Mongoid::Shell::Commands::Mongodump.new(
         excludeCollection: %w(test1 test2)


### PR DESCRIPTION
I misread something and believed that `--collection` can be specified multiple times, but it can't. The confusing result is that `mongodump` only respects the _last_ collection specified.

(In my defense, this "resolved" issue implied that it was possible: https://jira.mongodb.org/browse/TOOLS-189.)