### PR TITLE
add ssl and authDatabase support to all commands

### DIFF
--- a/lib/mongoid/shell/commands/base.rb
+++ b/lib/mongoid/shell/commands/base.rb
@@ -28,7 +28,7 @@ module Mongoid
             value = send(property)
             next unless value
             case value
-            when Boolean, TrueClass then key
+            when TrueClass then key
             when Array then value.map { |v| "#{key} #{v}" }.join(' ')
             else
               value = value.to_s

--- a/lib/mongoid/shell/commands/mongo.rb
+++ b/lib/mongoid/shell/commands/mongo.rb
@@ -7,7 +7,7 @@ module Mongoid
         include Mongoid::Shell::Properties::Username
         include Mongoid::Shell::Properties::Password
 
-        attr_accessor :eval, :nodb, :norc, :quiet, :ipv6
+        attr_accessor :eval, :nodb, :norc, :quiet, :ipv6, :ssl, :authenticationDatabase
 
         def initialize(attrs = {})
           super
@@ -26,7 +26,9 @@ module Mongoid
             '--nodb' => :nodb,
             '--norc' => :norc,
             '--quiet' => :quiet,
-            '--ipv6' => :ipv6
+            '--ipv6' => :ipv6,
+            '--ssl' => :ssl,
+            '--authenticationDatabase' => :authenticationDatabase
           })
         end
       end

--- a/lib/mongoid/shell/commands/mongodump.rb
+++ b/lib/mongoid/shell/commands/mongodump.rb
@@ -8,7 +8,7 @@ module Mongoid
         include Mongoid::Shell::Properties::Password
 
         attr_accessor :collection, :query, :out, :directoryperdb, :journal, :oplog, :repair, :forceTableScan, :dbpath, :ipv6, :excludeCollection,
-                      :excludeCollectionsWithPrefix
+                      :excludeCollectionsWithPrefix, :ssl, :authenticationDatabase
 
         def initialize(attrs = {})
           super
@@ -31,7 +31,9 @@ module Mongoid
             '--repair' => :repair,
             '--forceTableScan' => :forceTableScan,
             '--dbpath' => :dbpath,
-            '--ipv6' => :ipv6
+            '--ipv6' => :ipv6,
+            '--ssl' => :ssl,
+            '--authenticationDatabase' => :authenticationDatabase
           })
         end
       end

--- a/lib/mongoid/shell/commands/mongoimport.rb
+++ b/lib/mongoid/shell/commands/mongoimport.rb
@@ -21,12 +21,6 @@ module Mongoid
         end
 
         def vargs
-          super({
-
-          })
-        end
-
-        def vargs
           super var_options.merge(boolean_options)
         end
 

--- a/lib/mongoid/shell/commands/mongorestore.rb
+++ b/lib/mongoid/shell/commands/mongorestore.rb
@@ -7,7 +7,7 @@ module Mongoid
         include Mongoid::Shell::Properties::Username
         include Mongoid::Shell::Properties::Password
 
-        attr_accessor :host, :collection, :ipv6, :dbpath, :directoryperdb, :journal, :objcheck, :filter, :drop, :oplogReplay, :keepIndexVersion, :noIndexRestore, :restore
+        attr_accessor :host, :collection, :ipv6, :dbpath, :directoryperdb, :journal, :objcheck, :filter, :drop, :oplogReplay, :keepIndexVersion, :noIndexRestore, :restore, :ssl, :authenticationDatabase
 
         def initialize(attrs = {})
           super
@@ -34,6 +34,8 @@ module Mongoid
             '--oplogReplay' => :oplogReplay,
             '--keepIndexVersion' => :keepIndexVersion,
             '--noIndexRestore' => :noIndexRestore,
+            '--ssl' => :ssl,
+            '--authenticationDatabase' => :authenticationDatabase,
             'directory or filename to restore from' => :restore
           })
         end

--- a/lib/mongoid/shell/commands/mongostat.rb
+++ b/lib/mongoid/shell/commands/mongostat.rb
@@ -7,7 +7,7 @@ module Mongoid
         include Mongoid::Shell::Properties::Username
         include Mongoid::Shell::Properties::Password
 
-        attr_accessor :rowcount, :discover, :all, :http, :noheaders
+        attr_accessor :rowcount, :discover, :all, :http, :noheaders, :ssl, :authenticationDatabase
 
         def initialize(attrs = {})
           super
@@ -22,7 +22,9 @@ module Mongoid
             '--discover' => :discover,
             '--noheaders' => :noheaders,
             '--http' => :http,
-            '--all' => :all
+            '--all' => :all,
+            '--ssl' => :ssl,
+            '--authenticationDatabase' => :authenticationDatabase
           })
         end
       end

--- a/spec/mongoid/commands/mongo_spec.rb
+++ b/spec/mongoid/commands/mongo_spec.rb
@@ -39,6 +39,12 @@ describe Mongoid::Shell::Commands::Mongo do
           session: @session
         ).to_s).to eq 'mongo mongoid_shell_tests'
       end
+      it 'includes ssl and authenticationDatabase' do
+        expect(Mongoid::Shell::Commands::Mongo.new(
+          ssl: true,
+          authenticationDatabase: 'admin'
+        ).to_s).to eq 'mongo mongoid_shell_tests --ssl --authenticationDatabase admin'
+      end
     end
     context 'a replica set' do
       before :each do

--- a/spec/mongoid/commands/mongodump_spec.rb
+++ b/spec/mongoid/commands/mongodump_spec.rb
@@ -51,6 +51,12 @@ describe Mongoid::Shell::Commands::Mongodump do
           session: @session
         ).to_s).to eq 'mongodump --db mongoid_shell_tests'
       end
+      it 'includes ssl and authenticationDatabase' do
+        expect(Mongoid::Shell::Commands::Mongodump.new(
+          ssl: true,
+          authenticationDatabase: 'admin'
+        ).to_s).to eq 'mongodump --db mongoid_shell_tests --ssl --authenticationDatabase admin'
+      end
     end
     context 'a replica set' do
       before :each do

--- a/spec/mongoid/commands/mongorestore_spec.rb
+++ b/spec/mongoid/commands/mongorestore_spec.rb
@@ -49,6 +49,12 @@ describe Mongoid::Shell::Commands::Mongorestore do
           restore: 'a folder'
         ).to_s).to eq 'mongorestore --db mongoid_shell_tests "a folder"'
       end
+      it 'includes ssl and authenticationDatabase' do
+        expect(Mongoid::Shell::Commands::Mongorestore.new(
+          ssl: true,
+          authenticationDatabase: 'admin'
+        ).to_s).to eq 'mongorestore --db mongoid_shell_tests --ssl --authenticationDatabase admin'
+      end
     end
     context 'a replica set' do
       before :each do

--- a/spec/mongoid/commands/mongostat_spec.rb
+++ b/spec/mongoid/commands/mongostat_spec.rb
@@ -29,6 +29,12 @@ describe Mongoid::Shell::Commands::Mongostat do
           session: @session
         ).to_s).to eq 'mongostat'
       end
+      it 'includes ssl and authenticationDatabase' do
+        expect(Mongoid::Shell::Commands::Mongostat.new(
+          ssl: true,
+          authenticationDatabase: 'admin'
+        ).to_s).to eq 'mongostat --ssl --authenticationDatabase admin'
+      end
     end
     context 'a replica set' do
       before :each do


### PR DESCRIPTION
Some commands, such as `mongo` and `mongodump`, don't support `--ssl` and `--authDatabase` options. Here we add support for those options.